### PR TITLE
Add 'flex-wrap' class for flexible layout

### DIFF
--- a/Our.Iconic/src/elements/modal-settings-addpackage.element.ts
+++ b/Our.Iconic/src/elements/modal-settings-addpackage.element.ts
@@ -403,6 +403,10 @@ export default class AddPackageModal
             display: flex;
         }
 
+        .flex-wrap {
+            flex-wrap: wrap;
+        }
+
         .flex-column {
             flex-direction: column;
         }
@@ -540,7 +544,7 @@ export default class AddPackageModal
 
                     <uui-box headline="Filters">
                         <small>Use it to make available just specific icons, instead of the whole set. Leave blank to make all icons available.</small>
-                        <div class="flex">
+                        <div class="flex flex-wrap">
                             ${this.package.filteredIcons.map((filteredIcon, index) => html`
                                 <div class="icon-filter">                        
                                     <uui-button class="icon" compact label="icon" look="placeholder" type="button" color="default">


### PR DESCRIPTION
Added a new CSS class 'flex-wrap' to enable wrapping of flex items, so that the selected icons wrap instead of going off the side of the page.

Before:
<img width="836" height="275" alt="Screenshot 2025-10-29 110331" src="https://github.com/user-attachments/assets/a3519262-372f-45e5-b654-2b608a10fef1" />

After:
<img width="814" height="363" alt="Screenshot 2025-10-29 110445" src="https://github.com/user-attachments/assets/d782db2c-297b-48ac-89b1-5f6f4b85a794" />
